### PR TITLE
Update README.md with hls4ml 1.2.0 information

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ If you are using `hls4ml`, please make sure it is at least version 1.2:
 
 ```bash
 pip install hls4ml>=1.2.0
+
+Note that **version 1.2** has **not yet been released on PyPI**, so installing from GitHub is required.
+
+```bash
+pip install "hls4ml @ git+https://github.com/fastmachinelearning/hls4ml@main"
 ```
 
 ## Usage


### PR DESCRIPTION
The install from the pyproject.toml [test] version doesn't work right now since hls4ml>=1.2.0 isn't available on PyPi, I thought it would be good to let others know in the readme of the repo.