### PR TITLE
fix(layers): build multi-input layers with enable_iq=False

### DIFF
--- a/src/hgq/layers/core/base.py
+++ b/src/hgq/layers/core/base.py
@@ -339,7 +339,7 @@ class QLayerBaseMultiInputs(QLayerBase):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self._iqs_confs = None
+        self._iq_confs = None
         if self.enable_iq:
             self._iq_confs = iq_confs if iq_confs is not None else QuantizerConfig('default', 'datalane')
 
@@ -360,6 +360,9 @@ class QLayerBaseMultiInputs(QLayerBase):
         n_input = len(input_shape)
         for _input_shape in input_shape:
             assert isinstance(_input_shape, Iterable), f'each element of input_shape must be iterable, got {_input_shape}'
+
+        if not self.enable_iq:
+            return
 
         if isinstance(self.iq_confs, QuantizerConfig):
             self._iq_confs = [self.iq_confs] * n_input

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,5 +1,6 @@
 from math import log2, prod
 
+import keras
 import numpy as np
 import pytest
 from keras import layers, ops
@@ -190,3 +191,41 @@ class TestMeanPow2(TestQSum):
         else:
             scale = 1.0 / prod(input_shapes[ax % (len(input_shapes) + 1) - 1] for ax in axes)
         return 2.0 ** round(log2(scale))
+
+
+class TestMultiInputNoIQ:
+    """Regression: QLayerBaseMultiInputs must build/run/round-trip with enable_iq=False.
+
+    build() used to read ``iq_confs`` unconditionally while __init__ only created the
+    real ``_iq_confs`` attribute when enable_iq was True (it was assigned to a typo'd
+    name otherwise), so every multi-input layer raised AttributeError at build time --
+    which also made such models impossible to save or load.
+    """
+
+    @pytest.mark.parametrize('layer_cls', [QAdd, QSubtract, QMultiply, QMaximum, QMinimum])
+    def test_build_and_forward(self, layer_cls):
+        with QuantizerConfigScope(default_q_type='dummy'):
+            a, b = keras.Input((4,)), keras.Input((4,))
+            model = keras.Model([a, b], layer_cls(enable_iq=False)([a, b]))
+        xa, xb = np.ones((2, 4), 'float32'), 2 * np.ones((2, 4), 'float32')
+        assert ops.convert_to_numpy(model([xa, xb])).shape == (2, 4)
+
+    def test_forward_value(self):
+        with QuantizerConfigScope(default_q_type='dummy'):
+            a, b = keras.Input((4,)), keras.Input((4,))
+            model = keras.Model([a, b], QAdd(enable_iq=False)([a, b]))
+        xa, xb = np.ones((2, 4), 'float32'), 2 * np.ones((2, 4), 'float32')
+        out = ops.convert_to_numpy(model([xa, xb]))
+        np.testing.assert_allclose(out, 3.0, atol=1e-6)
+
+    @pytest.mark.parametrize('fmt', ['keras', 'h5'])
+    def test_roundtrip(self, fmt, tmp_path):
+        with QuantizerConfigScope(default_q_type='dummy'):
+            a, b = keras.Input((4,)), keras.Input((4,))
+            model = keras.Model([a, b], QAdd(enable_iq=False)([a, b]))
+        xa, xb = np.ones((2, 4), 'float32'), 2 * np.ones((2, 4), 'float32')
+        ref = ops.convert_to_numpy(model([xa, xb]))
+        path = f'{tmp_path}/m.{fmt}'
+        model.save(path)
+        loaded = keras.models.load_model(path)
+        np.testing.assert_array_equal(ref, ops.convert_to_numpy(loaded([xa, xb])))


### PR DESCRIPTION
## Problem
Constructing any `QLayerBaseMultiInputs` subclass with `enable_iq=False`
crashes at build:

    AttributeError: 'QAdd' object has no attribute 'iq_confs'

Because `build` runs during functional-model construction, the model can
never be built, and therefore never saved or loaded. Affects QAdd,
QSubtract, QMultiply, QMaximum, QMinimum, QAveragePow2, QDot, QEinsum.

## Root cause
`QLayerBaseMultiInputs.__init__` assigns the default to a misspelled
attribute `self._iqs_confs` (extra "s") and only sets the real
`self._iq_confs` when `enable_iq` is True. `build` then reads
`self.iq_confs` (i.e. `self._iq_confs`) and constructs the quantizers
unconditionally. The sibling `QLayerBaseSingleInput.build` already guards
this with `if self.enable_iq`; the multi-input path simply omitted it.

## Fix
- Initialise `self._iq_confs = None` (correct name) so the attribute always
  exists.
- Early-return from `build` when `enable_iq` is False, mirroring
  `QLayerBaseSingleInput`.

The `enable_iq=True` path is unchanged, and the serialized config key
(`iq_confs`) is unchanged, so existing checkpoints remain loadable.

## Testing
Added `TestMultiInputNoIQ` to `tests/test_ops.py`: builds, forwards, and
save/load round-trips multi-input layers with `enable_iq=False`.
