### PR TITLE
perf(layers): cache weight quantization in QGRU.call to avoid O(T) recompute

### DIFF
--- a/src/hgq/layers/rnn/gru.py
+++ b/src/hgq/layers/rnn/gru.py
@@ -185,6 +185,15 @@ class QGRUCell(QLayerBase, GRUCell):
             self._bq = Quantizer(bq_conf, name=f'{self.name}_bq')
         self._rhq = Quantizer(rhq_conf, name=f'{self.name}_rhq')
 
+        # Weight-quantization caching slots. When the cache is active (set by
+        # QGRU.call for the duration of one forward pass over the sequence), the
+        # qkernel / qrecurrent_kernel / qbias properties return the pre-quantized
+        # values instead of re-running the weight quantizers on every timestep.
+        self._cache_active = False
+        self._cached_qkernel = None
+        self._cached_qrecurrent_kernel = None
+        self._cached_qbias = None
+
     @property
     def paq(self):
         return self._paq
@@ -221,10 +230,14 @@ class QGRUCell(QLayerBase, GRUCell):
 
     @property
     def qkernel(self):
+        if self._cache_active and self._cached_qkernel is not None:
+            return self._cached_qkernel
         return self.kq(self.kernel)
 
     @property
     def qrecurrent_kernel(self):
+        if self._cache_active and self._cached_qrecurrent_kernel is not None:
+            return self._cached_qrecurrent_kernel
         return self.rkq(self.recurrent_kernel)
 
     @property
@@ -232,6 +245,8 @@ class QGRUCell(QLayerBase, GRUCell):
         if not self.use_bias:
             raise AttributeError(f'bias has been disabled for {self.name}.')
         assert self.bq is not None
+        if self._cache_active and self._cached_qbias is not None:
+            return self._cached_qbias
         return self.bq(self.bias)
 
     def qactivation(self, x):
@@ -584,6 +599,26 @@ class QGRU(QRNN, GRU):
         self.use_cudnn = False
         self.parallelization_factor = parallelization_factor
         self._set_unroll()
+
+    def call(self, sequences, initial_state=None, mask=None, training=False):
+        # Pre-quantize the (recurrent) kernel and bias ONCE per forward, then
+        # activate the cell cache so the per-timestep qkernel / qrecurrent_kernel
+        # / qbias property reads reuse the cached tensors instead of re-running
+        # the weight quantizers on every timestep. On backends without a cuDNN
+        # GRU path (e.g. torch) the layer lowers to a per-timestep scan over the
+        # cell, so this collapses O(T) redundant weight-quantizer work (and the
+        # O(T) autograd intermediates it retains for BPTT) down to O(1).
+        cell = self.cell
+        try:
+            cell._cached_qkernel = cell.kq(cell.kernel)
+            cell._cached_qrecurrent_kernel = cell.rkq(cell.recurrent_kernel)
+            if cell.use_bias:
+                cell._cached_qbias = cell.bq(cell.bias)
+            cell._cache_active = True
+            return super().call(sequences, initial_state=initial_state, mask=mask, training=training)
+        finally:
+            cell._cache_active = False
+            cell._cached_qkernel = cell._cached_qrecurrent_kernel = cell._cached_qbias = None
 
     def get_config(self):
         base_config = super().get_config()

--- a/tests/test_rnn.py
+++ b/tests/test_rnn.py
@@ -123,3 +123,38 @@ class TestQGRU(RNNTestBase):
         q_output = q_layer(input_data)
 
         assert ops.all(keras_output == q_output), f'{keras_output} != {q_output}'
+
+    def test_weight_quantizers_cached_per_forward(self, input_data, layer_kwargs):
+        """Weight quantizers (kq/rkq) must run once per forward, not once per timestep.
+
+        Pre-fix, QGRUCell.qkernel/qrecurrent_kernel re-ran the weight quantizers on
+        every timestep of the scan; QGRU.call now pre-quantizes once and caches.
+        """
+        layer_kwargs = layer_kwargs.copy()
+        layer_kwargs['activation'] = 'tanh'
+        layer_kwargs['recurrent_activation'] = 'sigmoid'
+
+        with QuantizerConfigScope(default_q_type='dummy'):
+            q_layer = self.layer_cls(
+                **layer_kwargs, enable_ebops=False, paq_conf=QuantizerConfig('dummy'), praq_conf=QuantizerConfig('dummy')
+            )
+        q_layer.build(input_data.shape)
+
+        cell = q_layer.cell
+        counts: dict[str, int] = {}
+        for name in ('kq', 'rkq'):
+            quantizer = getattr(cell, name)
+            original_call = quantizer.call
+
+            def counting(inputs, training=None, _orig=original_call, _name=name):
+                counts[_name] = counts.get(_name, 0) + 1
+                return _orig(inputs, training=training)
+
+            quantizer.call = counting
+
+        q_layer(input_data)
+
+        timesteps = input_data.shape[1]
+        assert timesteps > 1
+        assert counts.get('kq') == 1, f'kernel quantizer ran {counts.get("kq")}x over {timesteps} timesteps'
+        assert counts.get('rkq') == 1, f'recurrent-kernel quantizer ran {counts.get("rkq")}x over {timesteps} timesteps'


### PR DESCRIPTION
## Problem
On any backend without a cuDNN GRU path (notably `KERAS_BACKEND=torch`),
`keras.layers.GRU` lowers to a step-by-step scan over the cell, so `QGRUCell`
re-runs the three weight quantizers (`kq(kernel)`, `rkq(recurrent_kernel)`,
`bq(bias)`) on every one of the T timesteps, because `qkernel`,
`qrecurrent_kernel` and `qbias` are `@property` getters that quantize on each
access.

The weights are constant within a forward pass, so this is redundant work, and
under PyTorch autograd it is costly: each per-timestep quantizer call retains a
fresh set of clip/saturate/round intermediates for BPTT, so the graph grows
O(T) in weight-quantizer intermediates. This uses a lot of GPU memory
unnecessarily and can make long-sequence training run out of memory.

## Fix
Pre-quantize the (recurrent) kernel and bias once per forward in `QGRU.call`,
and have the cell `qkernel`/`qrecurrent_kernel`/`qbias` properties reuse the
cached tensors for the duration of the scan. The cache is cleared in a
`finally`, so standalone/eval use of the cell is byte-identical to before. The
per-timestep activation quantizers (iq/sq/paq/praq/rhq) take different inputs
each step and are untouched. This collapses the weight-quantizer work, and its
autograd intermediates, from O(T) to O(1) per forward.

## Correctness / parity (verified, torch backend)
- Forward output is bit-identical to the unpatched layer (max abs diff 0.0),
  for `reset_after` True and False.
- EBOPs value and `len(model.losses)` are identical to the unpatched layer. The
  fix lives directly in `QGRU.call` (not a subclass calling `super().call`), so
  the ebops `add_loss` wrapper still fires exactly once.
- The kernel quantizer runs once per forward instead of once per timestep.
- A training step runs and the weight-quantizer bitwidth parameters still
  receive gradient (the single cached quantizer call stays on the autograd path).
- `model.save` + `load_model` round-trips identically. No public API change.

## Testing
Added `test_weight_quantizers_cached_per_forward` to `TestQGRU` in
`tests/test_rnn.py`: it counts kernel / recurrent-kernel quantizer invocations
over a multi-timestep forward and asserts they run once, not once per timestep.
